### PR TITLE
publish(): delegate to koopa app r publish

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: AcidDevTools
 Title: Acid Genomics Developer Tools
 Description: Toolkit for R package development.
-Version: 0.7.8
-Date: 2026-03-02
+Version: 0.7.9
+Date: 2026-06-20
 Authors@R: c(
     person(
         "Michael", "Steinbaugh",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+## AcidDevTools 0.7.9 (2026-06-20)
+
+- `publish`: Delegate build, drat insert, S3 sync, and CloudFront
+  invalidation to `koopa app r publish`. The `repo` and `deploy`
+  parameters are removed; koopa reads `ACIDGENOMICS_REPO` from the
+  environment. Check and pkgdown steps remain in R as before.
+
 ## AcidDevTools 0.7.8 (2026-03-02)
 
 - `valid`: Removed internal override for `pkgType` passthrough. This wasn't

--- a/R/publish.R
+++ b/R/publish.R
@@ -1,35 +1,16 @@
 #' Build packages and publish to Acid Genomics repo
 #'
 #' @export
-#' @note Updated 2025-03-21.
+#' @note Updated 2026-06-20.
 #'
-#' @section Building from the command line:
-#'
-#' ```sh
-#' R CMD build ~/monorepo/r-packages/r-syntactic
-#' R CMD INSTALL --build syntactic_0.5.2.tar.gz
-#' R CMD check --as-cran syntactic_0.5.2.tar.gz
-#' # How to install from source:
-#' R CMD INSTALL syntactic_0.5.2.tar.gz
-#' # Or how to install binary (on macOS).
-#' R CMD INSTALL syntactic_0.5.2.tgz
-#' ```
-#'
-#' @section Building vignettes:
-#'
-#' If you run into problems with a vignette index not being detected, make sure
-#' the `.Rbuildignore` file does not contain `^vignettes$`. Ignoring `^Meta$`
-#' and `^doc$` is acceptable though.
-#'
-#' Note that `devtools::build` currently doesn't handle building vignettes
-#' for binary packages correctly.
+#' @details
+#' Delegates build, drat insert, S3 sync, and CloudFront invalidation to
+#' `koopa app r publish`. Optional package checks and pkgdown site deployment
+#' are handled in R before handing off to koopa.
 #'
 #' @param package `character`.
 #' Directory paths to R package source code.
 #' Vectorized, supporting the building of multiple packages in a single call.
-#'
-#' @param repo `character(1)`.
-#' Directory path to local R repository (e.g. `"r-acidgenomics-com"`).
 #'
 #' @param check `logical(1)`.
 #' Perform package checks prior to building package.
@@ -40,15 +21,8 @@
 #' @param pkgdown `logical(1)`.
 #' Build pkgdown website, if supported.
 #'
-#' @param deploy `logical(1)`.
-#' Deploy (push) the local repo to AWS S3.
-#'
 #' @return `logical(1)`.
 #' Boolean, indicating if package build was successful.
-#'
-#' @seealso
-#' - https://seandavi.github.io/post/build-linux-r-binary-packages/
-#' - https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html
 #'
 #' @examples
 #' ## > publish(
@@ -66,31 +40,24 @@
 publish <-
     function(
         package = getwd(),
-        repo = Sys.getenv("ACIDGENOMICS_REPO"),
         check = TRUE,
         tag = TRUE,
-        pkgdown = TRUE,
-        deploy = TRUE
+        pkgdown = TRUE
     ) {
         stopifnot(
             .requireNamespaces(c("desc", "devtools")),
-            .allAreSystemCommands(c("magick", "pandoc")),
+            .allAreSystemCommands(c("koopa", "magick", "pandoc")),
             .allAreDirs(package),
-            .isADir(repo),
             .isFlag(check),
             .isFlag(tag),
-            .isFlag(pkgdown),
-            .isFlag(deploy)
+            .isFlag(pkgdown)
         )
         package <- .realpath(package)
-        repo <- .realpath(repo)
         lapply(
             X = package,
-            repo = repo,
             check = check,
             pkgdown = pkgdown,
-            deploy = deploy,
-            FUN = function(package, repo, check, pkgdown, deploy) {
+            FUN = function(package, check, pkgdown) {
                 descFile <- file.path(package, "DESCRIPTION")
                 stopifnot(.isAFile(descFile))
                 if (isTRUE(check)) {
@@ -99,13 +66,12 @@ publish <-
                 if (isTRUE(pkgdown)) {
                     pkgdownDeployToAws(package = package)
                 }
-                tarballs <- build(package = package)
-                invisible(Map(
-                    file = tarballs,
-                    MoreArgs = list("repo" = repo),
-                    f = .insertPackage
+                koopa_args <- c("app", "r", "publish", package, "--no-check")
+                message(sprintf(
+                    "Running: koopa %s",
+                    paste(koopa_args, collapse = " ")
                 ))
-                invisible(lapply(X = tarballs, FUN = file.remove))
+                .shell(command = "koopa", args = koopa_args, wd = package)
                 if (isTRUE(tag)) {
                     message("Tagging on GitHub.")
                     name <-
@@ -149,64 +115,9 @@ publish <-
                         wd = package
                     )
                 }
-                .shell(
-                    command = "git",
-                    args = c(
-                        "checkout",
-                        .gitDefaultBranch(repo = repo)
-                    ),
-                    wd = repo
-                )
-                .shell(
-                    command = "git",
-                    args = c("fetch", "--all"),
-                    wd = repo
-                )
-                .shell(
-                    command = "git",
-                    args = "merge",
-                    wd = repo
-                )
-                .shell(
-                    command = "git",
-                    args = c("add", "./"),
-                    wd = repo
-                )
-                .shell(
-                    command = "git",
-                    args = c(
-                        "commit",
-                        "-m",
-                        paste0(
-                            "'Add ",
-                            basename(tarballs[["source"]]),
-                            ".'"
-                        )
-                    ),
-                    wd = repo
-                )
-                .shell(
-                    command = "git",
-                    args = "push",
-                    wd = repo
-                )
-                message(sprintf(
-                    "Successfully added '%s'.",
-                    basename(tarballs[["source"]])
-                ))
-                TRUE
+                invisible(TRUE)
             }
         )
-        if (isTRUE(deploy)) {
-            message(sprintf(
-                "Deploying packages to '%s'.",
-                "r.acidgenomics.com"
-            ))
-            .shell(
-                command = file.path(repo, "deploy"),
-                wd = repo
-            )
-        }
         invisible(TRUE)
     }
 


### PR DESCRIPTION
## Summary

- `publish()` now calls `koopa app r publish --no-check` instead of managing build, drat insert, S3 sync, and CloudFront invalidation itself
- Removes `repo` and `deploy` parameters (koopa reads `ACIDGENOMICS_REPO` from env)
- `check` and `pkgdown` steps remain in R as before; git tag step unchanged
- `build()` and `.insertPackage` retained for direct use (`rebuildBinary` still needs `.insertPackage`)
- Version bumped to 0.7.9

## Test plan

- [ ] Review `publish()` diff — check/pkgdown/tag logic preserved
- [ ] Confirm `koopa` is asserted as a system command in preconditions
- [ ] Merge → publish via `koopa app r publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)