### PR TITLE
Fix saveRdExamples: @param order to match function signature

### DIFF
--- a/R/saveRdExamples.R
+++ b/R/saveRdExamples.R
@@ -8,11 +8,11 @@
 #' @note Updated 2022-05-31.
 #'
 #' @inheritParams params
+#' @param package `character(1)`.
+#' Package name.
 #' @param rd `character` or `NULL`.
 #' R documentation name(s) from which to parse and save the working examples.
 #' If `NULL`, all documentation files containing examples will be saved.
-#' @param package `character(1)`.
-#' Package name.
 #'
 #' @return Invisible `character`.
 #' File path(s).

--- a/man/saveRdExamples.Rd
+++ b/man/saveRdExamples.Rd
@@ -4,15 +4,15 @@
 \alias{saveRdExamples}
 \title{Save R documentation examples}
 \usage{
-saveRdExamples(rd = NULL, package, dir = getwd())
+saveRdExamples(package, rd = NULL, dir = getwd())
 }
 \arguments{
+\item{package}{\code{character(1)}.
+Package name.}
+
 \item{rd}{\code{character} or \code{NULL}.
 R documentation name(s) from which to parse and save the working examples.
 If \code{NULL}, all documentation files containing examples will be saved.}
-
-\item{package}{\code{character(1)}.
-Package name.}
 
 \item{dir}{\code{character(1)}.
 Directory path.}


### PR DESCRIPTION
- Reorder `@param rd` and `@param package` in `saveRdExamples.R` to match the function signature (`package` first, `rd` second)\n- Fixes R CMD check code/documentation mismatch WARNING