### PR TITLE
Skip valid() test when internet unavailable

### DIFF
--- a/tests/testthat/test-valid.R
+++ b/tests/testthat/test-valid.R
@@ -1,4 +1,5 @@
 test_that("valid", {
+    skip_if_not(goalie::hasInternet())
     x <- valid()
     expect_type(x, "logical")
 })


### PR DESCRIPTION
`valid()` calls `utils::old.packages()` which requires network access. Skip the test when `goalie::hasInternet()` is FALSE to avoid failures in offline/restricted environments.