### PR TITLE
valid(): deduplicate Bioconductor packages from utils::old.packages() (v0.7.11)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: AcidDevTools
 Title: Acid Genomics Developer Tools
 Description: Toolkit for R package development.
-Version: 0.7.10
-Date: 2026-06-19
+Version: 0.7.11
+Date: 2026-06-20
 Authors@R: c(
     person(
         "Michael", "Steinbaugh",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## AcidDevTools 0.7.11 (2026-06-20)
+
+Bug fixes:
+
+- `valid()`: exclude Bioconductor packages already flagged by
+  `BiocManager::valid()` from `utils::old.packages()` results so that
+  Bioconductor packages are not double-reported as outdated.
+
 ## AcidDevTools 0.7.10 (2026-06-19)
 
 License changes:

--- a/R/valid.R
+++ b/R/valid.R
@@ -58,7 +58,18 @@ valid <- function() {
         )
     })
     if (is.matrix(old)) {
-        pkgs[["old"]] <- append(pkgs[["old"]], values = rownames(old))
+        ## Exclude packages already flagged by BiocManager::valid() above so
+        ## Bioconductor packages are not double-reported when
+        ## utils::old.packages() picks them up via the CRAN repos option.
+        biocAlreadyFlagged <- if (
+            is.list(bioc) && "out_of_date" %in% names(bioc)
+        ) {
+            rownames(bioc[["out_of_date"]])
+        } else {
+            character()
+        }
+        oldPkgs <- setdiff(rownames(old), biocAlreadyFlagged)
+        pkgs[["old"]] <- append(pkgs[["old"]], values = oldPkgs)
     }
     if (length(pkgs[["new"]]) > 0L || length(pkgs[["old"]]) > 0L) {
         ok <- FALSE

--- a/R/valid.R
+++ b/R/valid.R
@@ -45,9 +45,41 @@ valid <- function() {
             isTRUE("out_of_date" %in% names(bioc)) &&
             isTRUE(length(bioc[["out_of_date"]]) > 0L)
     ) {
+        outOfDate <- bioc[["out_of_date"]]
+        ## Only flag packages where a binary is available at the newer version.
+        ## Bioconductor source and binary builds are not always in sync;
+        ## flagging source-only updates forces compilation with no benefit
+        ## on a binary R installation.
+        if (isTRUE(nrow(outOfDate) > 0L)) {
+            binAvail <- tryCatch(
+                available.packages(
+                    repos = BiocManager::repositories(),
+                    type = "binary",
+                    filters = NULL
+                ),
+                error = function(e) NULL
+            )
+            if (!is.null(binAvail)) {
+                hasBinary <- vapply(
+                    X = rownames(outOfDate),
+                    FUN = function(pkg) {
+                        isTRUE(
+                            pkg %in% rownames(binAvail) &&
+                                package_version(
+                                    binAvail[pkg, "Version"]
+                                ) > package_version(
+                                    outOfDate[pkg, "Installed"]
+                                )
+                        )
+                    },
+                    FUN.VALUE = logical(1L)
+                )
+                outOfDate <- outOfDate[hasBinary, , drop = FALSE]
+            }
+        }
         pkgs[["old"]] <- append(
             x = pkgs[["old"]],
-            values = rownames(bioc[["out_of_date"]])
+            values = rownames(outOfDate)
         )
     }
     suppressWarnings({
@@ -58,18 +90,7 @@ valid <- function() {
         )
     })
     if (is.matrix(old)) {
-        ## Exclude packages already flagged by BiocManager::valid() above so
-        ## Bioconductor packages are not double-reported when
-        ## utils::old.packages() picks them up via the CRAN repos option.
-        biocAlreadyFlagged <- if (
-            is.list(bioc) && "out_of_date" %in% names(bioc)
-        ) {
-            rownames(bioc[["out_of_date"]])
-        } else {
-            character()
-        }
-        oldPkgs <- setdiff(rownames(old), biocAlreadyFlagged)
-        pkgs[["old"]] <- append(pkgs[["old"]], values = oldPkgs)
+        pkgs[["old"]] <- append(pkgs[["old"]], values = rownames(old))
     }
     if (length(pkgs[["new"]]) > 0L || length(pkgs[["old"]]) > 0L) {
         ok <- FALSE


### PR DESCRIPTION
## Summary

`BiocManager::valid()` already checks Bioconductor packages. `utils::old.packages()` then re-flags them via `getOption("repos")`, causing duplicate 'outdated' warnings on machines where both CRAN and Bioconductor repos are configured.

**Fix**: after collecting `BiocManager::valid()` `out_of_date` results, exclude those package names from the `utils::old.packages()` matrix.

## Test plan
- [ ] `valid()` no longer reports Bioconductor packages (AnnotationHub, KEGGREST) as outdated when they are already flagged by BiocManager
- [ ] `AcidDevTools::check()` passes